### PR TITLE
KB-8297 | [Backend] : Include a review step in the Events Flow and add meta fields to support competencies and associated files.

### DIFF
--- a/content-api/content-service/app/controllers/v4/EventController.scala
+++ b/content-api/content-service/app/controllers/v4/EventController.scala
@@ -44,7 +44,7 @@ class EventController @Inject()(@Named(ActorNames.EVENT_ACTOR) eventActor: Actor
         val headers = commonHeaders()
         val body = requestBody()
         val content = body.getOrDefault(schemaName, new java.util.HashMap()).asInstanceOf[java.util.Map[String, Object]];
-        if (content.containsKey("status") && content.get("status").equals("Live")) {
+        if (content.containsKey("status") && "Live".equals(content.get("status").toString)) {
             getErrorResponse(ApiId.UPDATE_EVENT, apiVersion, "VALIDATION_ERROR", "status update is restricted, use status APIs.")
         } else {
             content.putAll(headers)

--- a/content-api/content-service/app/controllers/v4/EventController.scala
+++ b/content-api/content-service/app/controllers/v4/EventController.scala
@@ -78,4 +78,17 @@ class EventController @Inject()(@Named(ActorNames.EVENT_ACTOR) eventActor: Actor
         setRequestContext(contentRequest, version, objectType, schemaName)
         getResult(ApiId.RETIRE_CONTENT, eventActor, contentRequest, version = apiVersion)
     }
+
+    override def reviewReject(identifier: String) = Action.async { implicit request =>
+        val headers = commonHeaders()
+        val body = requestBody()
+        val content = body.getOrDefault(schemaName, new java.util.HashMap()).asInstanceOf[java.util.Map[String, Object]];
+        content.putAll(headers)
+        content.putAll(Map("identifier" -> identifier).asJava)
+        val contentRequest = getRequest(content, headers, "rejectEvent")
+        contentRequest.put("mode", "edit")
+        setRequestContext(contentRequest, version, objectType, schemaName)
+        contentRequest.getContext.put("identifier", identifier);
+        getResult(ApiId.REJECT_EVENT, eventActor, contentRequest, version = apiVersion)
+    }
 }

--- a/content-api/content-service/app/controllers/v4/EventController.scala
+++ b/content-api/content-service/app/controllers/v4/EventController.scala
@@ -44,7 +44,7 @@ class EventController @Inject()(@Named(ActorNames.EVENT_ACTOR) eventActor: Actor
         val headers = commonHeaders()
         val body = requestBody()
         val content = body.getOrDefault(schemaName, new java.util.HashMap()).asInstanceOf[java.util.Map[String, Object]];
-        if (content.containsKey("status")) {
+        if (content.containsKey("status") && content.get("status").equals("Live")) {
             getErrorResponse(ApiId.UPDATE_EVENT, apiVersion, "VALIDATION_ERROR", "status update is restricted, use status APIs.")
         } else {
             content.putAll(headers)

--- a/content-api/content-service/app/utils/ApiId.scala
+++ b/content-api/content-service/app/utils/ApiId.scala
@@ -100,4 +100,5 @@ object ApiId {
 	val IMPORT_CSV = "api.collection.import"
 	val EXPORT_CSV = "api.collection.export"
 
+	val REJECT_EVENT = "api.event.review.reject"
 }

--- a/content-api/content-service/conf/routes
+++ b/content-api/content-service/conf/routes
@@ -113,6 +113,7 @@ POST      /event/v4/publish/:identifier             controllers.v4.EventControll
 GET       /event/v4/read/:identifier                controllers.v4.EventController.read(identifier:String, mode:Option[String], fields:Option[String])
 DELETE    /event/v4/discard/:identifier             controllers.v4.EventController.discard(identifier:String)
 DELETE    /private/event/v4/retire/:identifier      controllers.v4.EventController.retire(identifier:String)
+POST      /event/v4/reject/:identifier              controllers.v4.EventController.reviewReject(identifier:String)
 
 # EventSet v4 Api's
 POST    /eventset/v4/create                      controllers.v4.EventSetController.create

--- a/schemas/event/1.0/schema.json
+++ b/schemas/event/1.0/schema.json
@@ -36,7 +36,10 @@
             "enum": [
                 "Draft",
                 "Live",
-                "Retired"
+                "Retired",
+                "SentToPublish",
+                "Rejected",
+                "Cancelled"
             ],
             "default": "Draft"
         },


### PR DESCRIPTION
1.  Event Rejection API added for rejecting the events by SPV publisher
