### PR TITLE
Handled Deleting the node.img

### DIFF
--- a/content-api/content-actors/src/main/scala/org/sunbird/content/actors/EventActor.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/actors/EventActor.scala
@@ -66,6 +66,7 @@ class EventActor @Inject()(implicit oec: OntologyEngineContext, ss: StorageServi
     DataNode.read(request).flatMap { node =>
       // If the node exists, proceed with update and delete
       DataNode.updatev2(request, flag = true).flatMap { _ =>
+        DataNode.delete(request)
         request.put("identifier", updatedIdentifier.replace(".img", ""))
         verifyStandaloneEventAndApply(super.update, request, true)
       }
@@ -74,10 +75,6 @@ class EventActor @Inject()(implicit oec: OntologyEngineContext, ss: StorageServi
         // If the node does not exist, directly call verifyStandaloneEventAndApply
         request.put("identifier", updatedIdentifier.replace(".img", ""))
         verifyStandaloneEventAndApply(super.update, request, true)
-    }
-    DataNode.delete(request).recoverWith {
-      case ex: Exception =>
-        Future.successful(ResponseHandler.OK)
     }
   }
 


### PR DESCRIPTION
1. If we are deleting the datanode outside it is considering  the response structrue provided by the DateNode.delete "Node deleted successfully" due to which getting error in the getResult->setResponseEnvelope method saying null pointer exception.
2. So added the delete method inside the updateV2 and overriden the response of delete with verifyStandaloneEventAndApply method response.

