### PR TITLE
Cbrelease 4.8.32.1 (#189)

### DIFF
--- a/assessment-api/assessment-actors/src/main/scala/org/sunbird/actors/QuestionSetActor.scala
+++ b/assessment-api/assessment-actors/src/main/scala/org/sunbird/actors/QuestionSetActor.scala
@@ -15,6 +15,7 @@ import org.sunbird.graph.dac.model.Node
 import org.sunbird.graph.utils.NodeUtil
 import org.sunbird.managers.HierarchyManager.hierarchyPrefix
 import org.sunbird.managers.{AssessmentManager, HierarchyManager, UpdateHierarchyManager}
+import org.slf4j.LoggerFactory
 import org.sunbird.utils.RequestUtil
 
 import scala.collection.JavaConverters
@@ -23,6 +24,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class QuestionSetActor @Inject()(implicit oec: OntologyEngineContext) extends BaseActor {
 
+	private val logger = LoggerFactory.getLogger("QuestionSetActor")
 	implicit val ec: ExecutionContext = getContext().dispatcher
 	private lazy val importConfig = getImportConfig()
 	private lazy val importMgr = new ImportManager(importConfig)
@@ -84,7 +86,10 @@ class QuestionSetActor @Inject()(implicit oec: OntologyEngineContext) extends Ba
 		AssessmentManager.getValidatedNodeForPublish(request, "ERR_QUESTION_SET_PUBLISH").flatMap(node => {
 			AssessmentManager.getQuestionSetHierarchy(request, node).map(hierarchyString => {
 				AssessmentManager.validateQuestionSetHierarchy(hierarchyString.asInstanceOf[String], node.getMetadata.getOrDefault("createdBy", "").asInstanceOf[String])
+				// TODO: Debug logs for UAT/QA investigation - remove before production
+				logger.info("QuestionSetActor:publish - Before pushInstructionEvent for identifier: " + node.getIdentifier)
 				AssessmentManager.pushInstructionEvent(node.getIdentifier, node)
+				logger.info("QuestionSetActor:publish - After pushInstructionEvent for identifier: " + node.getIdentifier)
 				ResponseHandler.OK.putAll(Map[String, AnyRef]("identifier" -> node.getIdentifier.replace(".img", ""), "message" -> "Question is successfully sent for Publish").asJava)
 			})
 		})

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/actors/ContentActor.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/actors/ContentActor.scala
@@ -33,6 +33,7 @@ import javax.inject.Inject
 import scala.collection.JavaConverters._
 import scala.collection.{JavaConverters, Map}
 import scala.concurrent.{ExecutionContext, Future}
+import com.fasterxml.jackson.databind.ObjectMapper
 
 class ContentActor @Inject() (implicit oec: OntologyEngineContext, ss: StorageService) extends BaseActor {
 
@@ -53,6 +54,12 @@ class ContentActor @Inject() (implicit oec: OntologyEngineContext, ss: StorageSe
       retirementRequestTable,
       util.Arrays.asList(ContentConstants.RETITEMENT_PRIMARY_KEY)
     )
+
+		private val extendedReadContentKey: String = Platform.getString(ContentConstants.EXTENDED_READ_CONTENT_KEY, "extended_read_content_")
+
+	  private val extendedReadAssessmentKey: String = Platform.getString(ContentConstants.EXTENDED_READ_ASSESSMENT_KEY, "extended_read_assessment_")
+
+	  val mapper = new ObjectMapper()
 
 	override def onReceive(request: Request): Future[Response] = {
 		request.getOperation match {
@@ -255,6 +262,13 @@ class ContentActor @Inject() (implicit oec: OntologyEngineContext, ss: StorageSe
 				} catch {
 					case e: Exception => logger.info("Error while sending notification ", e)
 				}
+			}
+			try {
+				invalidateExtendedReadCaches(identifier, node.getMetadata)
+				logger.info(s"Extended-read cache invalidated for contentId=$identifier")
+			} catch {
+				case e: Exception =>
+					logger.warn(s"Failed to invalidate extended-read cache for $identifier", e)
 			}
 			ResponseHandler.OK.put("node_id", identifier).put("identifier", identifier)
 				.put("versionKey", node.getMetadata.get("versionKey"))
@@ -891,6 +905,68 @@ class ContentActor @Inject() (implicit oec: OntologyEngineContext, ss: StorageSe
 			}
 		}.map { resultMap =>
 			ResponseHandler.OK().putAll(resultMap.asJava)
+		}
+	}
+
+	private def invalidateExtendedReadCaches(
+																						contentId: String,
+																						contentMeta: java.util.Map[String, AnyRef]
+																					): Unit = {
+
+
+		val contentCacheKey = s"$extendedReadContentKey$contentId"
+		RedisCache.delete(contentCacheKey)
+		logger.info(s"Invalidated cache key=$contentCacheKey")
+
+		val assessmentIds = scala.collection.mutable.Set[String]()
+
+
+		val prelim = contentMeta.get(ContentConstants.PRELIMINARY_ASSESSMENT)
+		if (prelim != null && prelim.toString.trim.nonEmpty) {
+			assessmentIds += prelim.toString.trim
+			logger.info(s"Found preliminary assessmentId=$prelim")
+		}
+
+		val milestonesRaw = contentMeta.get(ContentConstants.MILESTONES_V1)
+
+		if (milestonesRaw != null && milestonesRaw.isInstanceOf[String]) {
+			val milestonesJson = milestonesRaw.asInstanceOf[String].trim
+
+			if (milestonesJson.nonEmpty && milestonesJson.startsWith("[")) {
+				try {
+					val rootNode = mapper.readTree(milestonesJson)
+
+					val it = rootNode.elements()
+					while (it.hasNext) {
+						val milestone = it.next()
+
+						val assessmentDetail = milestone.get(ContentConstants.ASSESSMENT_DETAIL)
+						if (assessmentDetail != null) {
+							val idNode = assessmentDetail.get(ContentConstants.IDENTIFIER)
+							if (idNode != null && !idNode.asText().trim.isEmpty) {
+								val assessmentId = idNode.asText().trim
+								assessmentIds += assessmentId
+								logger.info(s"Found milestone assessmentId=$assessmentId")
+							}
+						}
+					}
+
+				} catch {
+					case e: Exception =>
+						logger.error(
+							s"Failed to parse milestones_v1 JSON for contentId=$contentId",
+							e
+						)
+				}
+			}
+		}
+
+		val it = assessmentIds.iterator
+		while (it.hasNext) {
+			val assessmentId = it.next()
+			val assessmentCacheKey = s"$extendedReadAssessmentKey$assessmentId"
+			RedisCache.delete(assessmentCacheKey)
+			logger.info(s"Invalidated cache key=$assessmentCacheKey")
 		}
 	}
 

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/actors/ExtendedContentActor.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/actors/ExtendedContentActor.scala
@@ -58,6 +58,7 @@ class ExtendedContentActor @Inject() (implicit oec: OntologyEngineContext, ss: S
   // Configuration for extended read operations
   private val extendedContentReadCacheTTL: Int = Platform.getInteger(ContentConstants.EXTENDED_CONTENT_READ_CACHE_TTL, 86400)
   private val contentEnrichmentFields: util.List[String] = Platform.config.getStringList(ContentConstants.EXTENDED_CONTENT_ENRICHMENT_FIELDS).asScala.toList.asJava
+  private val childrenContentEnrichmentFields: util.List[String] = Platform.config.getStringList(ContentConstants.EXTENDED_CHILDREN_CONTENT_ENRICHMENT_FIELDS).asScala.toList.asJava
   private val contentHierarchyFields: Set[String] = Platform.config.getStringList(ContentConstants.EXTENDED_CONTENT_HIERARCHY_CHILDREN_FIELDS).asScala.toSet
   private val enrichChildrenCategories: Set[String] = Platform.config.getStringList(ContentConstants.EXTENDED_CONTENT_ENRICH_CHILDREN_CATEGORIES).asScala.toSet
   private val assessmentReadFields: util.List[String] = Platform.config.getStringList(ContentConstants.EXTENDED_CONTENT_ASSESSMENT_READ_FIELDS).asScala.toList.asJava
@@ -608,6 +609,8 @@ class ExtendedContentActor @Inject() (implicit oec: OntologyEngineContext, ss: S
       .and(QueryBuilder.set(ContentConstants.APPROVED_AT, new java.util.Date()))
       .and(QueryBuilder.set(ContentConstants.STATUS, statusValue))
       .and(QueryBuilder.set(ContentConstants.APPROVED_COMMENT, action))
+      .and(QueryBuilder.set(ContentConstants.LAST_ENROLLMENT_DATE_RQST, result.get(ContentConstants.LAST_ENROLLMENT_DATE_RQST)))
+      .and(QueryBuilder.set(ContentConstants.RETIREMENT_DATE_RQST, result.get(ContentConstants.RETIREMENT_DATE_RQST)))
       .and(QueryBuilder.set(ContentConstants.APPROVED_DATE, cassandraApprovedDate))
 
     CassandraConnector.getSession
@@ -985,12 +988,19 @@ class ExtendedContentActor @Inject() (implicit oec: OntologyEngineContext, ss: S
     if (cachedData != null && cachedData.nonEmpty) {
       try {
         val cachedResponse = JsonUtils.deserialize(cachedData, classOf[Response])
+        // Initialize params if null (required for BaseController.setResponseEnvelope)
+        if (cachedResponse.getParams == null) {
+          val params = new org.sunbird.common.dto.ResponseParams()
+          params.setStatus(org.sunbird.common.dto.ResponseParams.StatusType.successful.name())
+          cachedResponse.setParams(params)
+        }
         return Future.successful(cachedResponse)
       } catch {
         case e: Exception =>
           logger.warn(s"[extendedRead] Cache deserialization failed for $identifier", e)
       }
     }
+    request.getRequest.put(ContentConstants.FIELDS, contentEnrichmentFields)
     //Cache miss - perform standard content read
     read(request).flatMap { response =>
       //Extract content metadata from response
@@ -1103,7 +1113,18 @@ class ExtendedContentActor @Inject() (implicit oec: OntologyEngineContext, ss: S
             val enrichedCourse = new util.HashMap[String, AnyRef](course)
             // Merge fetched course data (includes hierarchy children)
             if (courseId.nonEmpty && courseMap.contains(courseId)) {
-              enrichedCourse.putAll(courseMap(courseId))
+              val courseData = courseMap(courseId)
+              // Defensive: Check if courseData is accidentally a Response object (shouldn't happen, but handle gracefully)
+              if (courseData.containsKey("result") && courseData.containsKey("responseCode") && courseData.containsKey("params")) {
+                logger.warn(s"[enrichMilestones] Course data for $courseId is incorrectly a Response object - extracting content")
+                val result = courseData.get("result").asInstanceOf[util.Map[String, AnyRef]]
+                if (result != null && result.containsKey(ContentConstants.CONTENT)) {
+                  enrichedCourse.putAll(result.get(ContentConstants.CONTENT).asInstanceOf[util.Map[String, AnyRef]])
+                }
+              } else {
+                // Normal case: courseData is a Map
+                enrichedCourse.putAll(courseData)
+              }
             }
             enrichedCourse.asInstanceOf[util.Map[String, AnyRef]]
           }.toList
@@ -1161,44 +1182,31 @@ class ExtendedContentActor @Inject() (implicit oec: OntologyEngineContext, ss: S
 
   /**
    * Fetches course read data + hierarchy children.
-   * Implements Redis caching with key pattern: extended_read_content_{{courseId}}
+   * Does NOT cache - caching happens at extendedRead level to avoid double caching.
    *
    * Process:
-   * 1. Check Redis cache for pre-computed course+hierarchy data
-   * 2. If not cached, fetch course metadata from Neo4j (DataNode.read)
-   * 3. Fetch hierarchy children from Cassandra (HierarchyManager.getHierarchy)
-   * 4. Filter children to include only configured fields
-   * 5. Merge course metadata + children
-   * 6. Cache the result and return
+   * 1. Fetch course metadata from Neo4j (DataNode.read)
+   * 2. Fetch hierarchy children from Cassandra (HierarchyManager.getHierarchy)
+   * 3. Filter children to include only configured fields
+   * 4. Merge course metadata + children and return
    *
    * Note: Course data comes from Neo4j, hierarchy structure comes from Cassandra
+   * Caching strategy: Only extendedRead caches the complete Response to avoid redundant cache entries
    *
    * @param courseId        Course identifier
    * @param originalRequest Request context (authentication, version, etc.)
    * @return Future[Map] with course read data and filtered children from hierarchy
    */
   private def fetchCourseWithHierarchy(courseId: String, originalRequest: Request): Future[util.Map[String, AnyRef]] = {
-    //Build cache key and check Redis cache
-    val cacheKey = s"${ContentConstants.EXTENDED_READ_CONTENT_CACHE_KEY_PREFIX}$courseId"
-    val cachedData = RedisCache.get(cacheKey)
-    if (cachedData != null && cachedData.nonEmpty) {
-      try {
-        val cachedMap = JsonUtils.deserialize(cachedData, classOf[java.util.Map[String, AnyRef]])
-        return Future.successful(cachedMap)
-      } catch {
-        case e: Exception =>
-          logger.warn(s"[fetchCourse] Cache deserialization failed for $courseId", e)
-      }
-    }
     val readRequest = new Request(originalRequest)
     readRequest.put(ContentConstants.IDENTIFIER, courseId)
-    readRequest.put(ContentConstants.FIELDS, contentEnrichmentFields)
+    readRequest.put(ContentConstants.FIELDS, childrenContentEnrichmentFields)
     val hierarchyRequest = new Request(originalRequest)
     hierarchyRequest.getRequest.put(ContentConstants.IDENTIFIER, courseId)
     hierarchyRequest.getRequest.put(ContentConstants.ROOT_ID, courseId)
     //Fetch course metadata from Neo4j
     val readFuture = DataNode.read(readRequest).map { node =>
-      val fields = contentEnrichmentFields
+      val fields = childrenContentEnrichmentFields
       val version = originalRequest.getContext.getOrDefault(ContentConstants.VERSION, "").asInstanceOf[String]
       val metadata = NodeUtil.serialize(node, fields, node.getObjectType.toLowerCase.replace("image", ""), version)
       metadata.put(ContentConstants.IDENTIFIER, node.getIdentifier.replace(".img", ""))
@@ -1233,13 +1241,6 @@ class ExtendedContentActor @Inject() (implicit oec: OntologyEngineContext, ss: S
       children.foreach { c =>
         val filteredChildren = filterChildrenFields(c)
         courseData.put(ContentConstants.CHILDREN, filteredChildren)
-      }
-      try {
-        val serializedData = JsonUtils.serialize(courseData)
-        RedisCache.set(cacheKey, serializedData, extendedContentReadCacheTTL)
-      } catch {
-        case e: Exception =>
-          logger.error(s"[fetchCourse] Cache set failed for $courseId", e)
       }
       courseData
     }
@@ -1311,7 +1312,11 @@ class ExtendedContentActor @Inject() (implicit oec: OntologyEngineContext, ss: S
 
   def read(request: Request): Future[Response] = {
     val responseSchemaName: String = request.getContext.getOrDefault(ContentConstants.RESPONSE_SCHEMA_NAME, "").asInstanceOf[String]
-    val fields: util.List[String] = JavaConverters.seqAsJavaListConverter(request.get("fields").asInstanceOf[String].split(",").filter(field => StringUtils.isNotBlank(field) && !StringUtils.equalsIgnoreCase(field, "null"))).asJava
+    val fields: util.List[String] = request.get("fields") match {
+      case fieldsList: util.List[_] => fieldsList.asInstanceOf[util.List[String]]
+      case fieldsStr: String => JavaConverters.seqAsJavaListConverter(fieldsStr.split(",").filter(field => StringUtils.isNotBlank(field) && !StringUtils.equalsIgnoreCase(field, "null"))).asJava
+      case _ => new util.ArrayList[String]()
+    }
     request.getRequest.put("fields", fields)
     DataNode.read(request).map(node => {
       val metadata: util.Map[String, AnyRef] = NodeUtil.serialize(node, fields, node.getObjectType.toLowerCase.replace("image", ""), request.getContext.get("version").asInstanceOf[String])

--- a/content-api/content-actors/src/main/scala/org/sunbird/content/util/ContentConstants.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/util/ContentConstants.scala
@@ -181,6 +181,7 @@ object ContentConstants {
     val CONTENT_COPY_FIELDS = "content.copy.fields"
     val ENRICHMENT_FIELDS = "content.enrichment.fields"
     val EXTENDED_CONTENT_ENRICHMENT_FIELDS = "extended.content.enrichment.fields"
+    val EXTENDED_CHILDREN_CONTENT_ENRICHMENT_FIELDS = "extended.children.content.enrichment.fields"
     val EXTENDED_CONTENT_READ_CACHE_TTL = "extendted.content.read.cache.ttl"
     val EXTENDED_CONTENT_HIERARCHY_CHILDREN_FIELDS = "extended.content.hierarchy.read.children.nodes.fields"
     val EXTENDED_CONTENT_ENRICH_CHILDREN_CATEGORIES = "extended.content.enrich.children.categories"
@@ -198,6 +199,8 @@ object ContentConstants {
     val PRELIMINARY_ASSESSMENT_DETAIL = "preliminaryAssessmentDetail"
     val ERROR = "error"
     val FIELDS = "fields"
+    val EXTENDED_READ_CONTENT_KEY = "extended.read.content.key"
+    val EXTENDED_READ_ASSESSMENT_KEY = "extended.read.assessment.key"
     val CREATED_DATE = "created_date"
     val APPROVED_DATE = "approved_date"
 }

--- a/content-api/content-service/conf/application.conf
+++ b/content-api/content-service/conf/application.conf
@@ -799,6 +799,7 @@ content.copy.fields = [
 user.search.api.url = "http://learner-service:9000/private/user/v1/search"
 
 # Content Enrichment Fields Configuration
+# Fields for parent entity (first call - Learning Pathway, Course, etc.)
 extended.content.enrichment.fields=[
 "identifier",
 "name",
@@ -812,13 +813,58 @@ extended.content.enrichment.fields=[
 "channel",
 "organisation",
 "createdBy",
+"createdFor",
 "createdOn",
 "lastUpdatedOn",
 "visibility",
 "audience",
 "primaryCategory",
 "additionalCategories",
-"contextCategory"]
+"contextCategory",
+"courseCategory",
+"framework",
+"milestones_v1",
+"preliminaryAssessment",
+"trackable",
+"credentials",
+"leafNodesCount",
+"completionCriteria",
+"showTimer",
+"maxAttempts",
+"learningObjective"]
+
+# Fields for children entities (recursive calls)
+extended.children.content.enrichment.fields=[
+"identifier",
+"name",
+"description",
+"contentType",
+"mimeType",
+"status",
+"duration",
+"appIcon",
+"posterImage",
+"channel",
+"organisation",
+"createdBy",
+"createdFor",
+"createdOn",
+"lastUpdatedOn",
+"visibility",
+"audience",
+"primaryCategory",
+"additionalCategories",
+"contextCategory",
+"courseCategory",
+"framework",
+"trackable",
+"credentials",
+"leafNodesCount",
+"completionCriteria",
+"showTimer",
+"maxAttempts",
+"learningObjective"]
+
 # Extended read API cache TTL (in seconds) - Default: 24 hours
 extendted.content.read.cache.ttl=86400
 # Fields to include in content hierarchy for the children nodes
@@ -915,3 +961,5 @@ extended.content.assessment.read.fields=[
 "showFeedback",
 "showSolutions",
 "timeLimits"]
+extended.read.content.key="extended_read_content_"
+extended.read.assessment.key = "extended_read_assessment_"


### PR DESCRIPTION
* 4.8.32.1 dev v3 (#184)

* KB-12556 | BE|DEV| API implementation of the new extended content read for learners pathway (#180)

1. Setting the content enrichment fields before calling the content read.

* KB-12556 | BE|DEV| API implementation of the new extended content read for learners pathway (#181)

* KB-12556 | BE|DEV| API implementation of the new extended content read for learners pathway

1. Added the child content enrichment fields

* Added the missing constant.

* KB-12556 | BE|DEV| API implementation of the new extended content read for learners pathway (#182)

fix: handle both String and List types for fields parameter to resolve ClassCastException in ExtendedContentActor.read()

* KB-12556 | BE|DEV| API implementation of the new extended content read for learners pathway (#183)

* KB-12556 | BE|DEV| API implementation of the new extended content read for learners pathway

- Fix NullPointerException by initializing ResponseParams after cache deserialization
- Implement single-level caching at extendedRead to prevent cache collision and redundancy

* fix: Add defensive handling for Response objects in milestone course enrichment

- When enriching milestone courses, putAll() was merging Response wrapper (params, responseCode, result) into course metadata
- Caused nested structure with params/responseCode appearing inside course objects
- Add defensive check to detect if courseData is a Response object (contains result/responseCode/params keys)
- Extract actual course content from result.content when Response detected

---------



* Cbrelease 4.8.32.1 (#185)

* Add enhanced error logging for async failures in extended content read

* KB-13031 Fix extended read cache invalidation

* KB-11956 | Retriggering the Content Publish API (#186)

1. Logs added for testing will remove revert before deploying to production.

* Cbrelease 4.8.32 (#187)

* Cbrelease 4.8.30 (#172)

* "fix for redis socket timeout"

* "fix for redis socket timeout"

---------



* Revert "Cbrelease 4.8.30 (#172)" (#174)

This reverts commit f65937649cee6839e7ebccc569a4c239566ade35.

---------



* KB-12452| DEV | BE | Notification while retirement - prod issue fixed (#188)

* KB-12452| DEV | BE | Notification while retirement

* KB-12452| DEV | BE | Notification while retirement

* KB-12452| DEV | BE | Notification while retirement - prod issue fixed

---------

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions: Java 11, scala-2.11, play-2.7.2
* Hardware versions: 2 CPU/ 4GB RAM

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

