### PR TITLE
fix: auto-set lastUpdatedOn in system/update API to sync with Elasticsearch

### DIFF
--- a/content-api/content-actors/src/main/scala/org/sunbird/content/actors/EventActor.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/actors/EventActor.scala
@@ -235,6 +235,11 @@ class EventActor @Inject()(implicit oec: OntologyEngineContext, ss: StorageServi
       // Extract attributes to be updated from the request body
       val attributesToUpdate = request.getRequest.asInstanceOf[java.util.Map[String, AnyRef]]
 
+      // AUTO-SET lastUpdatedOn if not provided
+      if (!attributesToUpdate.containsKey("lastUpdatedOn")) {
+        attributesToUpdate.put("lastUpdatedOn", DateUtils.formatCurrentDate)
+      }
+
       // Append attributes from the request to the node's metadata
       attributesToUpdate.forEach(new java.util.function.BiConsumer[String, AnyRef] {
         override def accept(key: String, value: AnyRef): Unit = {

--- a/ontology-engine/graph-engine_2.11/src/main/scala/org/sunbird/graph/nodes/DataNode.scala
+++ b/ontology-engine/graph-engine_2.11/src/main/scala/org/sunbird/graph/nodes/DataNode.scala
@@ -220,6 +220,12 @@ object DataNode {
       metadata.put("prevStatus", node.getMetadata.get("status"))
       metadata.put("lastStatusChangedOn", DateUtils.formatCurrentDate)
     }
+
+    // AUTO-SET lastUpdatedOn for system updates (if not already provided)
+    if (!metadata.containsKey("lastUpdatedOn")) {
+      metadata.put("lastUpdatedOn", DateUtils.formatCurrentDate)
+    }
+
     // Generate new request object for Each request
     val newRequest = new Request(request)
     newRequest.putAll(metadata)


### PR DESCRIPTION

## Problem
The `/v4/system/update` API endpoint was not updating the `lastUpdatedOn` field in Neo4j, causing stale timestamps in both Neo4j and Elasticsearch (which syncs via Flink connector). This led to incorrect "last modified" information being displayed in the UI.

## Root Cause
The systemUpdate flow bypasses `DefinitionNode.validate()`, which normally merges all request fields into the database node. Instead, systemUpdate only updates fields explicitly present in the request body.

While the publish pipeline auto-sets `lastUpdatedOn` via `ObjectUpdater.auditPropsUpdateQuery()`, the systemUpdate flow had no equivalent auto-enrichment logic, causing the timestamp to remain stale.

## Solution
Added automatic `lastUpdatedOn` enrichment in the systemUpdate flow, following the exact same pattern as the existing `lastStatusChangedOn` auto-update logic and the publish pipeline's approach.

### Changes Made

1. **DataNode.scala** (ontology-engine/graph-engine_2.11)
   - Modified `enrichHierarchyAndUpdate()` method (lines 224-227)
   - Auto-sets `lastUpdatedOn` if not provided in request
   - Fixes 4 actors: ContentActor, QuestionActor, QuestionSetActor, ExtendedContentActor

2. **EventActor.scala** (content-api/content-actors)
   - Modified `systemUpdate()` method (lines 238-241)
   - EventActor uses different code path (DataNode.updatev2), so requires separate fix
   - Auto-sets `lastUpdatedOn` if not provided in request

### Implementation Details
```scala
// Pattern followed (same as lastStatusChangedOn logic)
if (!metadata.containsKey("lastUpdatedOn")) {
  metadata.put("lastUpdatedOn", DateUtils.formatCurrentDate)
}



