### PR TITLE
fix: add missing DateUtils import in EventActor

### DIFF
--- a/content-api/content-actors/src/main/scala/org/sunbird/content/actors/EventActor.scala
+++ b/content-api/content-actors/src/main/scala/org/sunbird/content/actors/EventActor.scala
@@ -4,7 +4,7 @@ package org.sunbird.content.actors
 import org.apache.commons.lang3.StringUtils
 import org.slf4j.{Logger, LoggerFactory}
 import org.sunbird.cache.impl.RedisCache
-import org.sunbird.common.Platform
+import org.sunbird.common.{DateUtils, Platform}
 import org.sunbird.cloudstore.StorageService
 import org.sunbird.common.dto.{Request, Response, ResponseHandler}
 import org.sunbird.common.exception.{ClientException, ResponseCode}


### PR DESCRIPTION
Compilation failed for EventActor.scala with error: "not found: value DateUtils" at line 240.

The systemUpdate() method uses DateUtils.formatCurrentDate to auto-set the lastUpdatedOn field, but the DateUtils class was not imported.

